### PR TITLE
README: update Standalone Mach App build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ A [Zig](https://ziglang.org/) native GUI toolkit for whole applications or extra
 ### Standalone Mach App
 
 ```sh
-git clone --recurse-submodules https://github.com/david-vanderson/gui
+git clone https://github.com/david-vanderson/gui
 cd gui
+git submodule update --init
 zig build mach-test
 ```
 


### PR DESCRIPTION
`--recurse-submodules` will clones unneeded submodules like examples assets, Spirv-Tools, etc.