### PR TITLE
Quick fix for a crash in sdl-test.

### DIFF
--- a/sdl-test.zig
+++ b/sdl-test.zig
@@ -234,22 +234,22 @@ pub fn main() !void {
                         defer hbox.deinit();
                         try gui.label(@src(), "{d} {d} : {d}", .{ Sel.sel.start, Sel.sel.end, Sel.sel.cursor }, .{});
                         if (try gui.button(@src(), "Inc Start", .{})) {
-                            Sel.sel.start += 1;
+                            Sel.sel.incStart();
                         }
                         if (try gui.button(@src(), "Dec Start", .{})) {
-                            Sel.sel.start -= 1;
+                            Sel.sel.decStart();
                         }
                         if (try gui.button(@src(), "Inc End", .{})) {
-                            Sel.sel.end += 1;
+                            Sel.sel.incEnd();
                         }
                         if (try gui.button(@src(), "Dec End", .{})) {
-                            Sel.sel.end -= 1;
+                            Sel.sel.decEnd();
                         }
                         if (try gui.button(@src(), "Inc Cur", .{})) {
-                            Sel.sel.cursor += 1;
+                            Sel.sel.incCursor();
                         }
                         if (try gui.button(@src(), "Dec Cur", .{})) {
-                            Sel.sel.cursor -= 1;
+                            Sel.sel.decCursor();
                         }
                     }
                     var scroll = try gui.scrollArea(@src(), .{ .horizontal = .auto }, .{ .min_size_content = .{ .w = 150, .h = 100 } });

--- a/src/gui.zig
+++ b/src/gui.zig
@@ -4778,6 +4778,36 @@ pub const TextLayoutWidget = struct {
         start: usize = 0,
         end: usize = 0,
 
+        pub fn incCursor(self: *Selection) void {
+            self.cursor += 1;
+        }
+
+        pub fn decCursor(self: *Selection) void {
+            if (self.cursor <= 0) {
+                self.cursor = 0;
+            } else self.cursor -= 1;
+        }
+
+        pub fn incStart(self: *Selection) void {
+            self.start += 1;
+        }
+
+        pub fn decStart(self: *Selection) void {
+            if (self.start <= 0) {
+                self.start = 0;
+            } else self.start -= 1;
+        }
+
+        pub fn incEnd(self: *Selection) void {
+            self.end += 1;
+        }
+
+        pub fn decEnd(self: *Selection) void {
+            if (self.end <= 0) {
+                self.end = 0;
+            } else self.end -= 1;
+        }
+
         pub fn order(self: *Selection) void {
             if (self.end < self.start) {
                 const tmp = self.start;


### PR DESCRIPTION
Small fix for a underflow (in debug or ReleaseSafe)...so I guess not really a crash. Use inc and dec functions for uniformity. One could also just use the '**%=' operators to avoid the underflow in the example, but this leads to some strange looking/interacting with the text widget, as there is a wrap to the end of the input with the 'start/end/cursor', and it isn't very consistent with the way I think the widget should work. My opinion only...so take with a grain of salt :) 