### PR TITLE
Test proportional window scaling on startup

### DIFF
--- a/sdl-test.zig
+++ b/sdl-test.zig
@@ -27,6 +27,9 @@ pub fn main() !void {
     var scale_val: f32 = 1.0;
     var scale_mod: gui.enums.Mod = .none;
 
+    // This will get updated during window startup on displays larger than 1080p resolution
+    scale_val = SDLBackend.proportionalScale;
+
     //var rng = std.rand.DefaultPrng.init(0);
 
     main_loop: while (true) {


### PR DESCRIPTION
Just trying to make the startup of this example a little more readable on my 4k displays (old pet peeve of mine). Only do a proportional scaling if the resolution is above 1080p. Not sure if this should be added as a general option/function in 'gui' or not.